### PR TITLE
Add data/index.json manifest of dataset lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ https://cdn.jsdelivr.net/gh/kuhrissuh/fabric-color-dataset@v0.1.0/data/robert-ka
 
 Use `@main` for the latest (unreleased) data.
 
+A manifest of every line in the dataset lives at `data/index.json`, so consumers don't have to hardcode line paths:
+
+```
+https://cdn.jsdelivr.net/gh/kuhrissuh/fabric-color-dataset@v0.1.0/data/index.json
+```
+
 ## Stability
 
 See [STABILITY.md](STABILITY.md) for the full stability contract — what you can rely on across versions.

--- a/data/index.json
+++ b/data/index.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "1.0.0",
+  "generated_on": "2026-04-19",
+  "lines": [
+    {
+      "manufacturer_slug": "art-gallery-fabrics",
+      "line_slug": "pure-solids",
+      "path": "art-gallery-fabrics/pure-solids.json",
+      "manufacturer_name": "Art Gallery Fabrics",
+      "line_name": "Pure Solids",
+      "color_count": 215,
+      "data_version": "0.2.0"
+    },
+    {
+      "manufacturer_slug": "robert-kaufman",
+      "line_slug": "kona-cotton",
+      "path": "robert-kaufman/kona-cotton.json",
+      "manufacturer_name": "Robert Kaufman",
+      "line_name": "Kona Cotton",
+      "color_count": 370,
+      "data_version": "0.2.0"
+    }
+  ]
+}

--- a/pipeline/src/cli.py
+++ b/pipeline/src/cli.py
@@ -152,6 +152,10 @@ def _cmd_run(
     validate_mod.validate_file(data_path)
     print("validate: ok")
 
+    index_p = write_mod.write_index(today)
+    validate_mod.validate_index_file(index_p)
+    print(f"wrote: {index_p}")
+
     _print_summary(diff)
 
     if summary_path:

--- a/pipeline/src/validate.py
+++ b/pipeline/src/validate.py
@@ -13,6 +13,7 @@ import jsonschema
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCHEMA_PATH = REPO_ROOT / "schemas" / "v1.json"
+INDEX_SCHEMA_PATH = REPO_ROOT / "schemas" / "index_v1.json"
 
 
 class ValidationError(Exception):
@@ -29,6 +30,11 @@ def load_schema() -> dict[str, Any]:
         return json.load(f)
 
 
+def load_index_schema() -> dict[str, Any]:
+    with INDEX_SCHEMA_PATH.open() as f:
+        return json.load(f)
+
+
 def validate(data: dict[str, Any]) -> None:
     """Validate a parsed data file. Raises on first failure."""
     jsonschema.Draft202012Validator(load_schema()).validate(data)
@@ -38,6 +44,16 @@ def validate(data: dict[str, Any]) -> None:
 def validate_file(path: Path) -> None:
     with path.open() as f:
         validate(json.load(f))
+
+
+def validate_index(data: dict[str, Any]) -> None:
+    """Validate a parsed data/index.json against its schema."""
+    jsonschema.Draft202012Validator(load_index_schema()).validate(data)
+
+
+def validate_index_file(path: Path) -> None:
+    with path.open() as f:
+        validate_index(json.load(f))
 
 
 def _check_structural(data: dict[str, Any]) -> None:

--- a/pipeline/src/write.py
+++ b/pipeline/src/write.py
@@ -18,11 +18,16 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DATA_DIR = REPO_ROOT / "data"
 
 SCHEMA_VERSION = "1.0.0"
+INDEX_SCHEMA_VERSION = "1.0.0"
 GENERATOR_VERSION = "0.1.0"
 
 
 def data_path(config: LineConfig) -> Path:
     return DATA_DIR / config.manufacturer.slug / f"{config.line.slug}.json"
+
+
+def index_path(data_dir: Path = DATA_DIR) -> Path:
+    return data_dir / "index.json"
 
 
 def changelog_path(config: LineConfig) -> Path:
@@ -69,6 +74,42 @@ def write(
 
     _append_changelog(config, diff, today, new_version)
     return data_p, new_version
+
+
+def write_index(today: date, data_dir: Path = DATA_DIR) -> Path:
+    """Regenerate data/index.json by scanning per-line files on disk.
+
+    Reads from disk (not in-memory state) so a single-line pipeline run
+    refreshes the full manifest, and a one-time backfill works the same way.
+    """
+    entries = []
+    for path in data_dir.glob("*/*.json"):
+        with path.open() as f:
+            doc = json.load(f)
+        manufacturer = doc["manufacturer"]
+        line = doc["line"]
+        entries.append(
+            {
+                "manufacturer_slug": manufacturer["slug"],
+                "line_slug": line["slug"],
+                "path": f"{manufacturer['slug']}/{line['slug']}.json",
+                "manufacturer_name": manufacturer["name"],
+                "line_name": line["name"],
+                "color_count": doc["color_count"],
+                "data_version": doc["data_version"],
+            }
+        )
+    entries.sort(key=lambda e: (e["manufacturer_slug"], e["line_slug"]))
+
+    payload = {
+        "schema_version": INDEX_SCHEMA_VERSION,
+        "generated_on": today.isoformat(),
+        "lines": entries,
+    }
+
+    out = index_path(data_dir)
+    out.write_text(json.dumps(payload, indent=2) + "\n")
+    return out
 
 
 def load_prior_data_version(config: LineConfig) -> str:

--- a/pipeline/tests/test_write_index.py
+++ b/pipeline/tests/test_write_index.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+import validate
+import write
+
+
+def _line_doc(*, manufacturer_slug: str, manufacturer_name: str,
+              line_slug: str, line_name: str, color_count: int,
+              data_version: str) -> dict:
+    return {
+        "schema_version": "1.0.0",
+        "data_version": data_version,
+        "manufacturer": {
+            "name": manufacturer_name,
+            "slug": manufacturer_slug,
+            "website": f"https://example.com/{manufacturer_slug}",
+        },
+        "line": {
+            "name": line_name,
+            "slug": line_slug,
+            "substrate": "cotton",
+            "weight_oz_per_sq_yd": 4.0,
+            "width_inches": 44.0,
+        },
+        "notes": "",
+        "id_scheme": "manufacturer_sku",
+        "generated_on": "2026-04-19",
+        "generator_version": "0.1.0",
+        "color_count": color_count,
+        "colors": [],
+    }
+
+
+def _seed(data_dir: Path, doc: dict) -> None:
+    sub = data_dir / doc["manufacturer"]["slug"]
+    sub.mkdir(parents=True, exist_ok=True)
+    (sub / f"{doc['line']['slug']}.json").write_text(json.dumps(doc))
+
+
+def test_write_index_emits_sorted_entries(tmp_path: Path) -> None:
+    # Seed in reverse alphabetical order to prove the function sorts.
+    _seed(tmp_path, _line_doc(
+        manufacturer_slug="robert-kaufman",
+        manufacturer_name="Robert Kaufman",
+        line_slug="kona-cotton",
+        line_name="Kona Cotton",
+        color_count=370,
+        data_version="0.2.0",
+    ))
+    _seed(tmp_path, _line_doc(
+        manufacturer_slug="art-gallery-fabrics",
+        manufacturer_name="Art Gallery Fabrics",
+        line_slug="pure-solids",
+        line_name="Pure Solids",
+        color_count=215,
+        data_version="0.2.0",
+    ))
+
+    out = write.write_index(date(2026, 4, 19), data_dir=tmp_path)
+
+    assert out == tmp_path / "index.json"
+    payload = json.loads(out.read_text())
+    assert payload["schema_version"] == "1.0.0"
+    assert payload["generated_on"] == "2026-04-19"
+    assert [e["line_slug"] for e in payload["lines"]] == [
+        "pure-solids", "kona-cotton",
+    ]
+    assert payload["lines"][0] == {
+        "manufacturer_slug": "art-gallery-fabrics",
+        "line_slug": "pure-solids",
+        "path": "art-gallery-fabrics/pure-solids.json",
+        "manufacturer_name": "Art Gallery Fabrics",
+        "line_name": "Pure Solids",
+        "color_count": 215,
+        "data_version": "0.2.0",
+    }
+
+
+def test_write_index_passes_schema_validation(tmp_path: Path) -> None:
+    _seed(tmp_path, _line_doc(
+        manufacturer_slug="robert-kaufman",
+        manufacturer_name="Robert Kaufman",
+        line_slug="kona-cotton",
+        line_name="Kona Cotton",
+        color_count=370,
+        data_version="0.2.0",
+    ))
+
+    out = write.write_index(date(2026, 4, 19), data_dir=tmp_path)
+    validate.validate_index_file(out)
+
+
+def test_write_index_empty_data_dir(tmp_path: Path) -> None:
+    out = write.write_index(date(2026, 4, 19), data_dir=tmp_path)
+    payload = json.loads(out.read_text())
+    assert payload["lines"] == []
+    validate.validate_index_file(out)
+
+
+def test_write_index_ignores_top_level_index_json(tmp_path: Path) -> None:
+    # Pre-existing top-level index.json should not be picked up as a line file.
+    (tmp_path / "index.json").write_text("{}")
+    _seed(tmp_path, _line_doc(
+        manufacturer_slug="robert-kaufman",
+        manufacturer_name="Robert Kaufman",
+        line_slug="kona-cotton",
+        line_name="Kona Cotton",
+        color_count=370,
+        data_version="0.2.0",
+    ))
+
+    out = write.write_index(date(2026, 4, 19), data_dir=tmp_path)
+    payload = json.loads(out.read_text())
+    assert len(payload["lines"]) == 1
+    assert payload["lines"][0]["line_slug"] == "kona-cotton"

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -4,6 +4,8 @@ JSON Schema describing the shape of a fabric color line file. Consumers pin on `
 
 The authoritative definition is [`v1.json`](./v1.json). This document explains each field.
 
+A separate schema, [`index_v1.json`](./index_v1.json), describes [`/data/index.json`](../data/index.json) — the manifest listing every line file in the dataset. Each entry mirrors the per-file header (`manufacturer_slug`, `line_slug`, `manufacturer_name`, `line_name`, `path`, `color_count`, `data_version`) so consumers can render a picker without fetching every line file.
+
 ---
 
 ## File-level fields

--- a/schemas/index_v1.json
+++ b/schemas/index_v1.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Fabric Color Dataset Index v1",
+  "description": "Manifest of all line files in the dataset. One entry per data/{manufacturer}/{line}.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "generated_on", "lines"],
+  "properties": {
+    "schema_version": { "$ref": "#/$defs/semver" },
+    "generated_on": { "$ref": "#/$defs/date" },
+    "lines": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/line_entry" }
+    }
+  },
+  "$defs": {
+    "semver": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+    },
+    "line_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "manufacturer_slug",
+        "line_slug",
+        "path",
+        "manufacturer_name",
+        "line_name",
+        "color_count",
+        "data_version"
+      ],
+      "properties": {
+        "manufacturer_slug": { "$ref": "#/$defs/slug" },
+        "line_slug": { "$ref": "#/$defs/slug" },
+        "path": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*/[a-z0-9]+(-[a-z0-9]+)*\\.json$"
+        },
+        "manufacturer_name": { "type": "string", "minLength": 1 },
+        "line_name": { "type": "string", "minLength": 1 },
+        "color_count": { "type": "integer", "minimum": 0 },
+        "data_version": { "$ref": "#/$defs/semver" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #8.

## Summary

- New `data/index.json` lists every line in the dataset (manufacturer, slug, color count, current `data_version`, relative path) so consumers don't have to hardcode line paths.
- New schema at `schemas/index_v1.json` (`schema_version: "1.0.0"`); validated on write.
- `write_index()` scans `data/*/*.json` on disk rather than tracking in-memory state, so single-line pipeline runs refresh the full manifest and the backfill uses the same code path.
- Wired into the CLI: every successful `pipeline run` regenerates and validates `data/index.json` after the per-line write.
- README + schemas/README point consumers at the new manifest.

## Test plan

- [x] `pytest pipeline/tests/` — all 58 tests pass (4 new in `test_write_index.py`: sort order, schema validation, empty data dir, ignores top-level `index.json`)
- [x] Backfilled `data/index.json` covers both shipped lines (AGF Pure Solids, Kona Cotton) and validates against the new schema
- [ ] Reviewer: spot-check `data/index.json` matches the per-file headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)