### PR TITLE
Fix test_merge.py drift against AlgorithmicResult and ExtractionResult schemas

### DIFF
--- a/pipeline/tests/test_merge.py
+++ b/pipeline/tests/test_merge.py
@@ -66,7 +66,8 @@ def _extraction(
     )
     return ExtractionResult(
         parsed=parsed,
-        algorithmic=AlgorithmicResult(hex=algorithmic_hex or hex_, std_dev=1.0),
+        algorithmic=AlgorithmicResult(hex=algorithmic_hex or hex_, std_dev=1.0, std_a=1.0, std_b=1.0),
+        classification="photograph",
         vision=VisionResult(hex=hex_, confidence=confidence, observations="", warnings=[]),
         delta_e=0.5,
         final_hex=hex_,


### PR DESCRIPTION
## Summary
- `pipeline/tests/test_merge.py` was out of sync with the models changed in 23dd77b ("Add AGF Pure Solids line and photograph-vs-swatch classifier"). All 8 tests failed on `main` with `TypeError` because `AlgorithmicResult` now requires `std_a`/`std_b` and `ExtractionResult` now requires `classification`.
- Updated the `_extraction` fixture to pass `std_a=1.0`, `std_b=1.0`, and `classification="photograph"` (Kona's source material is fabric photography per CLAUDE.md).
- No production code touched — tests were brought in line with the schema, not the other way around.

## Test plan
- [x] `pytest pipeline/tests/test_merge.py` — 8/8 pass
- [x] `pytest pipeline/tests/` — full suite 84/84 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)