### PR TITLE
Restore test_merge fixture for AlgorithmicResult/ExtractionResult

### DIFF
--- a/pipeline/tests/test_merge.py
+++ b/pipeline/tests/test_merge.py
@@ -66,7 +66,8 @@ def _extraction(
     )
     return ExtractionResult(
         parsed=parsed,
-        algorithmic=AlgorithmicResult(hex=algorithmic_hex or hex_, std_dev=1.0),
+        algorithmic=AlgorithmicResult(hex=algorithmic_hex or hex_, std_dev=1.0, std_a=0.0, std_b=0.0),
+        classification="photograph",
         vision=VisionResult(hex=hex_, confidence=confidence, observations="", warnings=[]),
         delta_e=0.5,
         final_hex=hex_,


### PR DESCRIPTION
## Summary
- `pipeline/tests/test_merge.py::_extraction()` fell out of sync with `pipeline/src/models.py`: `AlgorithmicResult` gained `std_a` / `std_b` (a/b channel spread for the photograph-vs-swatch classifier), and `ExtractionResult` gained `classification`.
- All 8 tests in `test_merge.py` were failing with `TypeError: AlgorithmicResult.__init__() missing 2 required positional arguments: 'std_a' and 'std_b'`.
- Pass `std_a=0.0, std_b=0.0` and `classification="photograph"` to keep the fixture exercising the vision-consensus merge path the tests assert on. The tests don't assert on either new field.

## Test plan
- [x] `pytest pipeline/tests/test_merge.py` — 8 failed → 8 passed
- [x] Full suite: 97 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)