### PR TITLE
Add decision log to docs/decisions.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,3 +74,4 @@ Git tags are immutable. Tag releases manually; don't tag on every weekly merge.
 - Review diffs carefully before committing.
 - Push back on deviations from the plan. If something feels off against `docs/project-plan.md`, say so before implementing.
 - Update this file when a constraint needs reinforcing across sessions.
+- Log significant decisions in `docs/decisions.md` — date, what was decided, why, alternatives rejected.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,7 +4,19 @@ Chronological record of design and architecture decisions for the fabric-color-d
 
 ---
 
-## 2026-04-17 — Robert Kaufman Kona Cotton as v0.1 target
+## 2026-04-20 — Low-confidence colors are spot-checked but never overridden
+
+**Status:** accepted
+
+Low-confidence colors (ΔE ≥ 7) get a manual visual spot-check to catch gross extraction failures — cases where the displayed swatch is clearly the wrong hue (e.g. green rendering where the fabric is purple). If the pipeline value is in the right ballpark, it is left as-is.
+
+The alternative — overriding low-confidence values with manually corrected hex — was deliberately rejected. Manual overrides would make the dataset non-reproducible: a future pipeline run would disagree with the stored value, creating noise and requiring ongoing human maintenance. Leaving the pipeline value in place means every run produces the same output from the same inputs. The `low` confidence flag is the signal to consumers that the value may be approximate; it is not an invitation to patch it.
+
+Consequence: low-confidence colors carry a known approximation error, but the dataset remains fully pipeline-reproducible. Manual overrides (`hex_method: "manual_override"`) are reserved for cases where the pipeline value is categorically wrong, not merely imprecise.
+
+---
+
+
 
 **Status:** accepted
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,120 @@
+# Decision Log
+
+Chronological record of design and architecture decisions for the fabric-color-dataset project. Captures *what* was decided, *why*, and what alternatives were considered. Full rationale for each decision lives in `docs/project-plan.md`; this file is the scannable index.
+
+---
+
+## 2026-04-17 — Robert Kaufman Kona Cotton as v0.1 target
+
+**Status:** accepted
+
+Art Gallery Fabrics Pure Solids was the initial candidate. AGF was ruled out because it publishes flat rendered color blocks rather than fabric photography. The vision-extraction pipeline exists specifically to sample real woven fabric — flat renders defeat the purpose and would leave the most complex pipeline stage untested. Kona Cotton uses real fabric photography (visible weave texture), so it exercises the full pipeline end-to-end.
+
+AGF was not dropped — it was deferred to v0.2 as an algorithmic-only line. Adding it after Kona is a straightforward additive step.
+
+---
+
+## 2026-04-17 — Permanent color IDs
+
+**Status:** accepted
+
+Format: `{manufacturer-slug}-{line-slug}-{sku}`, lowercased. Once a color is published, its ID is immutable. The ID never follows a name change; `aliases` handles the rename case.
+
+The alternative (numeric auto-increment IDs) was rejected because it requires a central registry and breaks if two people generate IDs independently. SKU-based IDs are self-contained: a consumer storing only the ID can always locate the color without querying the dataset.
+
+Consequence: the format must be defined before the first release and cannot be revised without a major version bump.
+
+---
+
+## 2026-04-17 — Dates, not timestamps, in data files
+
+**Status:** accepted
+
+All time fields (`first_seen`, `source_collected_on`, `generated_on`) are ISO 8601 dates (`YYYY-MM-DD`). Sub-day precision is available in git history if ever needed.
+
+Timestamps (e.g. `2026-04-17T14:32:00Z`) would make every weekly pipeline run produce a noisy diff even when no color data changed. Date-only fields keep diffs meaningful — a changed date signals a real data update, not just a re-run.
+
+---
+
+## 2026-04-17 — Split license: CC0 for data, MIT for pipeline
+
+**Status:** accepted
+
+`/data` and `/schemas` are the product that downstream tools depend on — they are CC0 (public domain dedication) so consumers face zero license friction. `/pipeline` and `/configs` are the generator code — MIT.
+
+Blurring the line (e.g. a single repo-wide license) would either encumber the data with code-license terms or leave the pipeline without a clear license. The split keeps the two concerns clean.
+
+---
+
+## 2026-04-17 — No auto-merging of data PRs
+
+**Status:** accepted
+
+The pipeline can open PRs against `/data` but cannot merge them. Every data PR gets human review.
+
+Automated merges are tempting for a weekly update cycle, but the dataset is the product — a corrupt merge is a breaking change for every downstream consumer pinned to the affected version. The review step is the last safety net before data reaches jsDelivr.
+
+---
+
+## 2026-04-17 — Three confidence buckets, not a float
+
+**Status:** accepted
+
+`hex_confidence` is an enum: `high` | `medium` | `low`. The buckets are determined by ΔE distance in LAB space between vision and algorithmic extractions:
+- `high`: ΔE < 3, no vision warnings
+- `medium`: ΔE < 3 with warnings, OR 3 ≤ ΔE < 7
+- `low`: ΔE ≥ 7
+
+A float confidence score (e.g. 0.0–1.0) was considered and rejected. Floats imply false precision and force every consumer to independently choose a threshold. Three buckets push the threshold decision into the dataset where it can be documented and agreed on once.
+
+---
+
+## 2026-04-17 — Halt on anomaly, don't auto-correct
+
+**Status:** accepted
+
+If a pipeline run detects >20% hex changes or >10% low-confidence rate, it halts with an error rather than opening a PR.
+
+The alternative — opening a PR and flagging the anomaly in the PR description — was rejected because it puts the burden of catching a corrupted run on the reviewer. Halting forces investigation before any data reaches the PR stage. Better to miss a weekly update than to publish bad data.
+
+---
+
+## 2026-04-17 — Derived color values excluded from schema
+
+**Status:** accepted
+
+`hex_rgb`, `hex_hsl`, `hex_lab`, and similar derived representations are not stored in the dataset. They are computable from `hex` in one line of code in any language.
+
+Storing them creates drift risk (derived values could become inconsistent with `hex` after a manual override or correction) and adds schema fields that carry no new information. Consumers that need derived values compute them locally.
+
+---
+
+## 2026-04-18 — Vision prompt versioned as immutable files
+
+**Status:** accepted
+
+Prompt files live at `pipeline/prompts/hex_extraction_v{N}.md`. Editing an existing prompt file is not allowed — a change means creating a new file (`v2`) alongside the old one. The content hash of the prompt file is part of the extraction cache key.
+
+This design ensures that bumping the prompt version forces full re-extraction (intended behavior) and that cached entries remain valid as long as the image hash and prompt hash are unchanged. Modifying `v1` in place would silently invalidate cached entries that still reference it.
+
+---
+
+## 2026-04-18 — Prompt v1 passed calibration; proceed to full run
+
+**Status:** accepted
+
+A 12-SKU calibration set was run against prompt v1. All 12 vision responses returned `confidence: "high"` with empty `warnings` lists. Consensus bucket distribution: 5 high · 5 medium · 2 low (ΔE-based). Visual spot-checks on the two low-confidence entries (Ocean, Tomato) confirmed vision was correct and the algorithmic extractor was the disagreer.
+
+The 2/12 = 16.7% low-confidence rate exceeds the 10% halt threshold, but that threshold is designed for run-to-run drift detection against existing data, not a first run against an empty dataset. No prompt changes were needed. Full 370-color run authorized.
+
+See `docs/vision-prompt.md` for the full calibration table and spot-check notes.
+
+---
+
+## 2026-04-19 — Art Gallery Fabrics Pure Solids added as algorithmic-only in v0.2
+
+**Status:** accepted
+
+AGF was deferred at v0.1 (see 2026-04-17 entry above). It was added in v0.2 as an algorithmic-only line: `hex_confidence` is not applicable, and `hex_method` is `algorithmic` for all colors. The vision pipeline is not exercised on AGF because its swatch images are flat renders rather than fabric photography.
+
+This is the expected post-v0.1 path. No schema changes were required — the existing `hex_method` enum already included `algorithmic`, and the schema is additive. Data version bumped to 0.2.0 (new fabric line = minor bump per semver rules).

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -8,6 +8,8 @@ Art Gallery Fabrics Pure Solids was the initial candidate but was deferred. AGF 
 
 The core principle running through every decision below: **build the smallest version that does the thing, defer everything speculative, optimize for the case where you're the only user for a while.** The schema and the stability contract are load-bearing; most other infrastructure is not.
 
+A chronological index of key decisions (what was chosen, why, alternatives rejected) lives in [`docs/decisions.md`](decisions.md). When making tradeoff calls, check there first — many questions have already been settled.
+
 ---
 
 ## Schema


### PR DESCRIPTION
Backfills 10 key decisions made during v0.1 and v0.2 development, sourced
from project-plan.md, CLAUDE.md, CHANGELOG.md, and vision-prompt.md.
Adds a one-line reminder to CLAUDE.md to keep the log updated.

https://claude.ai/code/session_01Q3A8xhFCgfR6pnhvmbtyMN