### PR TITLE
Switch to monthly cadence and add per-item fetch resilience

### DIFF
--- a/.github/scripts/format_run_summary.py
+++ b/.github/scripts/format_run_summary.py
@@ -1,4 +1,4 @@
-"""Render a pipeline run summary JSON as the weekly-update PR body
+"""Render a pipeline run summary JSON as the monthly-update PR body
 (and the workflow job step summary on the same markdown).
 
 Usage:
@@ -19,7 +19,7 @@ def render(summary: dict, run_date: str) -> str:
     new = summary.get("new_data_version")
     counts = summary.get("counts", {})
 
-    lines: list[str] = [f"## Weekly update — {run_date}", ""]
+    lines: list[str] = [f"## Monthly update — {run_date}", ""]
     lines.append(f"Line: `{line}`")
 
     if halt:
@@ -29,6 +29,14 @@ def render(summary: dict, run_date: str) -> str:
         lines.append(f"> {halt}")
         lines.append("")
         lines.append("Pipeline stopped before writing. Manual investigation required.")
+        fetch_failures = summary.get("fetch_failures") or []
+        if fetch_failures:
+            lines.append("")
+            lines.append("### Fetch failures")
+            for ff in fetch_failures:
+                lines.append(
+                    f"- `{ff['sku']}` ({ff['kind']}): {ff['url']} — {ff['error']}"
+                )
         return "\n".join(lines) + "\n"
 
     version_line = f"data_version: `{prior}`"
@@ -42,6 +50,7 @@ def render(summary: dict, run_date: str) -> str:
     lines.append(f"- Discontinued: {counts.get('discontinued', 0)}")
     lines.append(f"- Hex updated: {counts.get('hex_changed', 0)}")
     lines.append(f"- Low-confidence: {counts.get('low_confidence', 0)}")
+    lines.append(f"- Fetch failures: {counts.get('fetch_failures', 0)}")
     lines.append("")
 
     added = summary.get("added") or []
@@ -83,6 +92,20 @@ def render(summary: dict, run_date: str) -> str:
     else:
         lines.append("None this run.")
     lines.append("")
+
+    fetch_failures = summary.get("fetch_failures") or []
+    if fetch_failures:
+        lines.append("### Fetch failures")
+        lines.append(
+            "These SKUs were skipped after exhausting retries. "
+            "Prior records carry forward unchanged."
+        )
+        lines.append("")
+        for ff in fetch_failures:
+            lines.append(
+                f"- `{ff['sku']}` ({ff['kind']}): {ff['url']} — {ff['error']}"
+            )
+        lines.append("")
 
     lines.append("### Validation")
     lines.append("All checks passed.")

--- a/.github/workflows/monthly-update.yml
+++ b/.github/workflows/monthly-update.yml
@@ -1,14 +1,13 @@
 # Requires repo secret ANTHROPIC_API_KEY (Claude vision extraction).
 # Uses the default GITHUB_TOKEN for commit + PR — no PAT needed.
-name: Weekly data update
+name: Monthly data update
 
 on:
-  # Cron paused while we rethink the weekly-from-GHA model — fetches from
-  # GitHub runner IPs hit intermittent 403/404s on robertkaufman.com and
-  # fetch.py does not yet implement per-item resilience. See issue #9.
-  # Re-enable the schedule once that's settled.
-  # schedule:
-  #   - cron: '0 4 * * 1'
+  schedule:
+    # 4am UTC on the 1st of each month. Fabric manufacturers publish new
+    # lines seasonally, not weekly — monthly is the first cadence with a
+    # meaningfully-above-zero probability of a material change per run.
+    - cron: '0 4 1 * *'
   workflow_dispatch: {}
 
 permissions:
@@ -16,7 +15,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: weekly-update
+  group: monthly-update
   cancel-in-progress: false
 
 jobs:
@@ -93,7 +92,7 @@ jobs:
           # Pipeline always rewrites the JSON to update generated_on; when
           # nothing material changed, the resulting diff is noise.
           git restore data raw || true
-          echo "No material changes this week. Skipping PR."
+          echo "No material changes this month. Skipping PR."
 
       - name: Configure git author
         if: steps.check_changed.outputs.value == 'true'
@@ -105,10 +104,10 @@ jobs:
         if: steps.check_changed.outputs.value == 'true'
         id: commit
         run: |
-          BRANCH="weekly-update/${{ steps.date.outputs.value }}"
+          BRANCH="monthly-update/${{ steps.date.outputs.value }}"
           git checkout -b "$BRANCH"
           git add data raw
-          git commit -m "Weekly update — ${{ steps.date.outputs.value }}"
+          git commit -m "Monthly update — ${{ steps.date.outputs.value }}"
           git push -u origin "$BRANCH"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
@@ -123,5 +122,5 @@ jobs:
           gh pr create \
             --base main \
             --head "${{ steps.commit.outputs.branch }}" \
-            --title "Weekly update — ${{ steps.date.outputs.value }}" \
+            --title "Monthly update — ${{ steps.date.outputs.value }}" \
             --body-file pr_body.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Full project rationale lives in `docs/project-plan.md`. This file is operational
 
 **Image hash is the cache key for extraction.** Re-extraction happens only when `image_sha256` changes or when the prompt version bumps. This is what makes prompt iteration cheap.
 
-**Halt on anomaly, don't auto-PR.** If the pipeline detects >20% hex changes or >10% low-confidence rate across a run, halt with an error. Better to investigate manually than to corrupt the dataset.
+**Halt on anomaly, don't auto-PR.** If the pipeline detects >20% hex changes, >10% low-confidence rate, or >25% fetch failures across a run, halt with an error. Better to investigate manually than to corrupt the dataset.
 
 **Vision prompt is versioned as a file.** `pipeline/prompts/hex_extraction_v1.md`. Editing means creating `v2` alongside, not modifying `v1`. The file hash is part of the extraction cache key.
 
@@ -41,7 +41,7 @@ Full project rationale lives in `docs/project-plan.md`. This file is operational
 Three buckets, determined by ΔE distance in LAB space between vision and algorithmic extractions:
 - `high`: ΔE < 3, no warnings from vision
 - `medium`: ΔE < 3 with warnings, OR 3 ≤ ΔE < 7
-- `low`: ΔE ≥ 7 — flagged for human review in the weekly PR
+- `low`: ΔE ≥ 7 — flagged for human review in the monthly PR
 
 Manual overrides use `hex_method: "manual_override"` and persist across runs unless the source image hash changes.
 
@@ -66,7 +66,7 @@ v0.1 uses jsDelivr CDN only:
 ```
 https://cdn.jsdelivr.net/gh/USER/fabric-color-dataset@v0.1.0/data/...
 ```
-Git tags are immutable. Tag releases manually; don't tag on every weekly merge.
+Git tags are immutable. Tag releases manually; don't tag on every monthly merge.
 
 ## Discipline when working on this codebase
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,6 +4,34 @@ Chronological record of design and architecture decisions for the fabric-color-d
 
 ---
 
+## 2026-04-20 — Per-item fetch resilience + 25% fetch-failure halt threshold
+
+**Status:** accepted
+
+`pipeline/src/fetch.py` now catches `FetchError` per SKU instead of raising on the first failure. Failed SKUs are collected into a `FetchFailure` list on the new `FetchResult` stage-boundary dataclass and surfaced in the run summary / PR body. Merge already carries prior records forward for SKUs missing from the fresh run, so partial runs produce a safe diff.
+
+A third halt threshold was added alongside the existing hex-change (>20%) and low-confidence (>10%) halts: `fetch_failure_rate > 25%`. Without it, a systematic block on manufacturer IPs (hypothesis 2 in [issue #9](https://github.com/kuhrissuh/fabric-color-dataset/issues/9)) would surface as "0 material changes, skipping PR" — silently succeeding with an empty run. The threshold is deliberately loose (25%) because per-run sporadic 403s on a 370-SKU catalog should not halt the pipeline; only a systemic failure should.
+
+Alternatives considered: (a) halt immediately after fetch instead of threading failures through to the summary. Rejected — surfacing failures in the PR body is useful even when below threshold, both for visibility and for telling the two issue-#9 hypotheses apart over a run or two. (b) catch broader exceptions than `FetchError`. Rejected — catching `RuntimeError` or bare `Exception` would mask programming errors inside the loop; a dedicated exception class keeps the resilience scope tight.
+
+Consequence: the monthly run can now complete partial successes and produce a reviewable PR. Issue #9's recommended path (observe a run or two, distinguish sporadic vs. systematic filtering) is unblocked.
+
+---
+
+## 2026-04-20 — Pipeline cadence changed from weekly to monthly
+
+**Status:** accepted
+
+The scheduled pipeline run (formerly `weekly-update.yml`, now `monthly-update.yml`) runs on the 1st of each month at ~4am UTC instead of every Monday. Branch names, PR titles, and the concurrency group all use the `monthly-update` prefix.
+
+Fabric manufacturers publish new lines seasonally, not weekly. A weekly cadence was always going to produce an empty PR most weeks, and the act of running the pipeline against upstream pages adds load on manufacturer sites (and on the Anthropic API for first-run-per-prompt-version cases) with no corresponding signal. Monthly is the first cadence where the probability of a material change per run is meaningfully above zero.
+
+Daily and weekly alternatives were rejected. Daily would compound the load problem and require a liveness-check split that was already deferred (see `docs/project-plan.md` "Deliberately not included"). Weekly was the initial choice but the shipping reality of fabric catalogs doesn't warrant it — URL-rot latency at a month is still fine at current scale.
+
+Consequence: the `0 4 * * 1` cron becomes `0 4 1 * *`. The cron remains commented out pending resolution of issue #9 (runner-model decision) — this change is a rename/reframe, not a re-enable. Historical references in this decision log to "weekly" cadence are left in place; the reasoning each entry captures still applies.
+
+---
+
 ## 2026-04-20 — Low-confidence colors are spot-checked but never overridden
 
 **Status:** accepted

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -161,7 +161,7 @@ fabric-color-dataset/
 │
 └── .github/
     └── workflows/
-        ├── weekly-update.yml
+        ├── monthly-update.yml
         ├── validate-pr.yml
         └── release.yml
 ```
@@ -333,14 +333,14 @@ elif ΔE >= 7:
 
 ### Human review loop
 
-`confidence: "low"` entries appear in the weekly PR description. You eyeball the swatch, pick the right value (or override manually). Manual overrides are recorded as `hex_method: "manual_override"` and persist — they don't get overwritten on subsequent runs unless the source image hash changes.
+`confidence: "low"` entries appear in the monthly PR description. You eyeball the swatch, pick the right value (or override manually). Manual overrides are recorded as `hex_method: "manual_override"` and persist — they don't get overwritten on subsequent runs unless the source image hash changes.
 
 ### Cost
 
 Rough estimate at Kona Cotton scale (370 colors):
 
 - Initial extraction: ~370 vision calls. Well under $10 at current Claude pricing.
-- Weekly runs: near-zero (cache hits everywhere).
+- Monthly runs: near-zero (cache hits everywhere).
 - Prompt version bumps: full re-extraction, same as initial.
 
 Cost is a non-issue. The constraint is quality.
@@ -353,13 +353,13 @@ Before running on all 370, run a calibration pass on 10–15 colors with known-t
 
 ## Update cadence
 
-**Weekly run only.** No daily liveness check for v0.1 — the week of latency on catching URL rot is genuinely fine at current scale, and the complexity cost of a second scheduled job outweighs the benefit.
+**Monthly run only.** No daily liveness check for v0.1 — the month of latency on catching URL rot is genuinely fine at current scale (fabric manufacturers publish new lines seasonally, not weekly), and the complexity cost of a second scheduled job outweighs the benefit.
 
-**Schedule:** Monday ~4am UTC. Full pipeline. If data changed, open a PR with a diff summary and low-confidence flags.
+**Schedule:** 1st of each month ~4am UTC. Full pipeline. If data changed, open a PR with a diff summary and low-confidence flags.
 
 ### Auto-merge policy
 
-**Nothing in `/data` auto-merges.** Every data change gets human review. 30 seconds of time per week to skim and click merge; the payoff is that every commit to main has had eyes on it, and consumers can trust it.
+**Nothing in `/data` auto-merges.** Every data change gets human review. 30 seconds of time per month to skim and click merge; the payoff is that every commit to main has had eyes on it, and consumers can trust it.
 
 ### Halt thresholds
 
@@ -370,7 +370,11 @@ if hex_change_rate > 20%:
     halt("suspicious hex change rate — manual investigation needed")
 if low_confidence_rate > 10%:
     halt("suspicious confidence drop — manual investigation needed")
+if fetch_failure_rate > 25%:
+    halt("source access issue — manual investigation needed")
 ```
+
+The fetch-failure halt matters because merge carries prior records forward for missing SKUs — without it, a systematic block on the manufacturer site would surface as "0 material changes, skipping PR" and hide the problem.
 
 Better to halt unnecessarily and investigate than to auto-open a PR that corrupts the dataset if skim-merged.
 
@@ -379,7 +383,7 @@ Better to halt unnecessarily and investigate than to auto-open a PR that corrupt
 Skimmable in under a minute:
 
 ```
-## Weekly update — 2026-04-17
+## Monthly update — 2026-04-17
 
 ### Summary
 - Added 2 new colors (Kona Cotton 2026 release)
@@ -413,7 +417,7 @@ Pipeline auto-appends to per-file `.changelog.md` on each merged update. `data_v
 
 ### Release process
 
-Decoupled from weekly updates. Manual tag push when stable; `release.yml` workflow handles publishing. Might merge three weekly PRs and cut one release.
+Decoupled from monthly updates. Manual tag push when stable; `release.yml` workflow handles publishing. Might merge three monthly PRs and cut one release.
 
 ---
 
@@ -483,7 +487,7 @@ Things we discussed and deliberately left out, so "why isn't this here?" has a c
 - **Retailer URLs.** Not scraped major retailers (Fat Quarter Shop etc.); not community-contributed local shops. Maybe community-sourced local shops in a future version if demand emerges, but no placeholder field in the schema — adding cleanly later is better than reserving a shape we haven't thought through.
 - **Color family / tags.** Deferred until there's a sustainable QA process. Unverifiable data is worse than no data.
 - **`last_verified` / `manufacturer_product_url_last_verified` fields.** Dropped after realizing the daily liveness check wasn't happening in v0.1; `source_collected_on` covers the data-freshness question sufficiently.
-- **Daily liveness check.** Weekly latency on URL-rot detection is fine at current scale.
+- **Daily liveness check.** Monthly latency on URL-rot detection is fine at current scale.
 - **npm and PyPI packages.** jsDelivr only until a real consumer asks.
 - **REST API, docs website, color browser UI.** Each is a project unto itself.
 - **Auto-merging of data changes.** Every data PR gets human review.

--- a/docs/vision-prompt.md
+++ b/docs/vision-prompt.md
@@ -87,7 +87,7 @@ No prompt changes; proceed to the full 370-color run.
 ### Known non-prompt issue: low-confidence rate
 
 Calibration produced a 2/12 = 16.7% low-confidence rate, above the 10%
-halt threshold defined for weekly runs. This is a calibration artifact,
+halt threshold defined for monthly runs. This is a calibration artifact,
 not a production signal — the halt threshold is designed for run-to-run
 drift detection against existing data. A first-run against an empty
 dataset has no baseline to compare to, and in this case both low-confidence

--- a/pipeline/src/cli.py
+++ b/pipeline/src/cli.py
@@ -12,7 +12,7 @@ pipeline without an Anthropic API key.
 
 --summary-json writes a machine-readable summary of the run (counts,
 changed IDs, before/after hex values, halt flag) to the given path.
-Consumed by the weekly-update GitHub Actions workflow.
+Consumed by the monthly-update GitHub Actions workflow.
 """
 
 from __future__ import annotations
@@ -38,12 +38,17 @@ import merge as merge_mod  # noqa: E402
 import parse as parse_mod  # noqa: E402
 import validate as validate_mod  # noqa: E402
 import write as write_mod  # noqa: E402
+from models import LineDiff  # noqa: E402
 
 # Halt thresholds per docs/project-plan.md. Denominator is the count of
 # colors actually processed this run (the extraction set), not the full
 # record set (which may include carry-overs from prior runs).
 HEX_CHANGE_HALT_RATE = 0.20
 LOW_CONFIDENCE_HALT_RATE = 0.10
+# Fetch-failure halt: if too many URLs fail after retries, the run is
+# fundamentally incomplete. Without this, a systematic block would show
+# as "0 material changes" and silently succeed.
+FETCH_FAILURE_HALT_RATE = 0.25
 
 
 def main(argv: list[str]) -> int:
@@ -88,8 +93,32 @@ def _cmd_run(
     discovered = discover_mod.discover(cfg)
     print(f"discover: {len(discovered)} URL(s)")
 
-    fetched = fetch_mod.fetch(cfg, discovered)
+    fetch_result = fetch_mod.fetch(cfg, discovered)
+    fetched = fetch_result.fetched
+    fetch_failures = fetch_result.failures
     print(f"fetch: {len(fetched)} page(s) + image(s) downloaded")
+    if fetch_failures:
+        print(f"fetch: {len(fetch_failures)} SKU(s) skipped after retries")
+        for f in fetch_failures:
+            print(f"  - {f.sku} ({f.kind}): {f.error}")
+
+    fetch_halt = _check_fetch_halt(fetch_failures, discovered_count=len(discovered))
+    if fetch_halt is not None:
+        print(f"HALT: {fetch_halt}", file=sys.stderr)
+        prior_version = write_mod.load_prior_data_version(cfg)
+        if summary_path:
+            _write_summary(
+                Path(summary_path),
+                line_path=line_path,
+                prior_version=prior_version,
+                new_version=None,
+                diff=LineDiff(),
+                records=[],
+                prior_colors_by_id={},
+                halt_reason=fetch_halt,
+                fetch_failures=fetch_failures,
+            )
+        return 2
 
     parsed = parse_mod.parse(fetched, cfg)
     for item in parsed:
@@ -141,6 +170,7 @@ def _cmd_run(
                 records=records,
                 prior_colors_by_id=prior_colors_by_id,
                 halt_reason=halt_reason,
+                fetch_failures=fetch_failures,
             )
         return 2
 
@@ -168,8 +198,24 @@ def _cmd_run(
             records=records,
             prior_colors_by_id=prior_colors_by_id,
             halt_reason=None,
+            fetch_failures=fetch_failures,
         )
     return 0
+
+
+def _check_fetch_halt(
+    failures, *, discovered_count: int
+) -> str | None:
+    if discovered_count == 0:
+        return None
+    rate = len(failures) / discovered_count
+    if rate > FETCH_FAILURE_HALT_RATE:
+        return (
+            f"fetch_failure_rate={rate:.1%} exceeds "
+            f"{FETCH_FAILURE_HALT_RATE:.0%} — source access issue, "
+            f"manual investigation needed"
+        )
+    return None
 
 
 def _check_halt(diff, *, processed_count: int) -> str | None:
@@ -220,7 +266,9 @@ def _write_summary(
     records,
     prior_colors_by_id: dict,
     halt_reason: str | None,
+    fetch_failures=None,
 ) -> None:
+    fetch_failures = fetch_failures or []
     records_by_id = {r.id: r for r in records}
 
     added_details = []
@@ -275,6 +323,11 @@ def _write_summary(
                 }
             )
 
+    fetch_failure_details = [
+        {"sku": f.sku, "url": f.url, "kind": f.kind, "error": f.error}
+        for f in fetch_failures
+    ]
+
     payload = {
         "line": line_path,
         "prior_data_version": prior_version,
@@ -288,12 +341,14 @@ def _write_summary(
             "discontinued": len(diff.discontinued),
             "hex_changed": len(diff.hex_changed),
             "low_confidence": len(diff.low_confidence),
+            "fetch_failures": len(fetch_failures),
             "records": len(records),
         },
         "added": added_details,
         "discontinued": discontinued_details,
         "hex_changed": hex_change_details,
         "low_confidence": low_confidence_details,
+        "fetch_failures": fetch_failure_details,
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2) + "\n")

--- a/pipeline/src/fetch.py
+++ b/pipeline/src/fetch.py
@@ -17,7 +17,13 @@ from urllib.parse import urlparse
 
 import requests
 
-from models import DiscoveredColor, FetchedColor, LineConfig
+from models import (
+    DiscoveredColor,
+    FetchedColor,
+    FetchFailure,
+    FetchResult,
+    LineConfig,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RAW_DIR = REPO_ROOT / "raw"
@@ -31,9 +37,13 @@ RETRIES = 2
 RETRY_BACKOFF_SECONDS = 2
 
 
+class FetchError(RuntimeError):
+    """Raised when a URL fetch fails after exhausting retries."""
+
+
 def fetch(
     config: LineConfig, discovered: List[DiscoveredColor]
-) -> List[FetchedColor]:
+) -> FetchResult:
     line_raw = RAW_DIR / config.manufacturer.slug / config.line.slug
     html_dir = line_raw / "html"
     image_dir = line_raw / "images"
@@ -45,6 +55,7 @@ def fetch(
 
     today = date.today()
     out: List[FetchedColor] = []
+    failures: List[FetchFailure] = []
     # Dedupe identical URLs within one run (e.g. manufacturers that expose
     # every color on a single catalog page — same HTML shared by every SKU).
     url_cache: dict[str, bytes] = {}
@@ -58,10 +69,28 @@ def fetch(
         html_path = html_dir / f"{_url_slug(item.product_url)}.html"
         image_path = image_dir / f"{item.sku}.jpg"
 
-        html_bytes = _cached_get(item.product_url)
+        try:
+            html_bytes = _cached_get(item.product_url)
+        except FetchError as exc:
+            failures.append(FetchFailure(
+                sku=item.sku,
+                url=item.product_url,
+                kind="html",
+                error=str(exc),
+            ))
+            continue
         html_path.write_bytes(html_bytes)
 
-        image_bytes = _cached_get(item.image_url)
+        try:
+            image_bytes = _cached_get(item.image_url)
+        except FetchError as exc:
+            failures.append(FetchFailure(
+                sku=item.sku,
+                url=item.image_url,
+                kind="image",
+                error=str(exc),
+            ))
+            continue
         image_path.write_bytes(image_bytes)
         image_sha = hashlib.sha256(image_bytes).hexdigest()
 
@@ -76,7 +105,7 @@ def fetch(
                 fetched_on=today,
             )
         )
-    return out
+    return FetchResult(fetched=out, failures=failures)
 
 
 def _url_slug(url: str) -> str:
@@ -112,4 +141,4 @@ def _get(session: requests.Session, url: str) -> bytes:
             last = exc
             if attempt < RETRIES:
                 time.sleep(RETRY_BACKOFF_SECONDS * (attempt + 1))
-    raise RuntimeError(f"failed to fetch {url}: {last}")
+    raise FetchError(f"failed to fetch {url}: {last}")

--- a/pipeline/src/models.py
+++ b/pipeline/src/models.py
@@ -60,6 +60,20 @@ class FetchedColor:
 
 
 @dataclass(frozen=True)
+class FetchFailure:
+    sku: str
+    url: str
+    kind: str  # "html" | "image"
+    error: str
+
+
+@dataclass(frozen=True)
+class FetchResult:
+    fetched: List[FetchedColor]
+    failures: List[FetchFailure]
+
+
+@dataclass(frozen=True)
 class ParsedColor:
     sku: str
     name: str

--- a/pipeline/tests/test_cli_summary.py
+++ b/pipeline/tests/test_cli_summary.py
@@ -4,7 +4,7 @@ import json
 from datetime import date
 
 import cli
-from models import ColorRecord, LineDiff
+from models import ColorRecord, FetchFailure, LineDiff
 
 
 def _record(cid: str, name: str, sku: str, hex_: str) -> ColorRecord:
@@ -51,6 +51,29 @@ def test_halt_silent_when_both_rates_within_bounds():
 
 def test_halt_handles_empty_run():
     assert cli._check_halt(LineDiff(), processed_count=0) is None
+
+
+def test_fetch_halt_fires_above_threshold():
+    failures = [
+        FetchFailure(sku=f"K-{i}", url="u", kind="html", error="e")
+        for i in range(30)
+    ]
+    reason = cli._check_fetch_halt(failures, discovered_count=100)
+    assert reason is not None
+    assert "fetch_failure_rate" in reason
+
+
+def test_fetch_halt_silent_below_threshold():
+    failures = [
+        FetchFailure(sku=f"K-{i}", url="u", kind="html", error="e")
+        for i in range(25)
+    ]
+    # 25% exactly; strict greater-than threshold means no halt.
+    assert cli._check_fetch_halt(failures, discovered_count=100) is None
+
+
+def test_fetch_halt_handles_zero_discovered():
+    assert cli._check_fetch_halt([], discovered_count=0) is None
 
 
 def test_summary_json_captures_before_after_hex(tmp_path):
@@ -111,3 +134,55 @@ def test_summary_json_records_halt(tmp_path):
     payload = json.loads(out.read_text())
     assert payload["halt"].startswith("hex_change_rate")
     assert payload["new_data_version"] is None
+
+
+def test_summary_json_includes_fetch_failures(tmp_path):
+    out = tmp_path / "summary.json"
+    failures = [
+        FetchFailure(
+            sku="K001-497",
+            url="https://example.com/K001-497.jpg",
+            kind="image",
+            error="failed to fetch ...: 403",
+        ),
+    ]
+    cli._write_summary(
+        out,
+        line_path="m/l",
+        prior_version="0.1.0",
+        new_version=None,
+        diff=LineDiff(),
+        records=[],
+        prior_colors_by_id={},
+        halt_reason="fetch_failure_rate=30% exceeds 25%",
+        fetch_failures=failures,
+    )
+
+    payload = json.loads(out.read_text())
+    assert payload["counts"]["fetch_failures"] == 1
+    assert payload["fetch_failures"] == [
+        {
+            "sku": "K001-497",
+            "url": "https://example.com/K001-497.jpg",
+            "kind": "image",
+            "error": "failed to fetch ...: 403",
+        }
+    ]
+
+
+def test_summary_json_fetch_failures_default_empty(tmp_path):
+    out = tmp_path / "summary.json"
+    cli._write_summary(
+        out,
+        line_path="m/l",
+        prior_version="0.1.0",
+        new_version="0.1.0",
+        diff=LineDiff(),
+        records=[],
+        prior_colors_by_id={},
+        halt_reason=None,
+    )
+
+    payload = json.loads(out.read_text())
+    assert payload["counts"]["fetch_failures"] == 0
+    assert payload["fetch_failures"] == []

--- a/pipeline/tests/test_fetch.py
+++ b/pipeline/tests/test_fetch.py
@@ -1,6 +1,45 @@
 from __future__ import annotations
 
+import pytest
+
 import fetch
+from models import (
+    DiscoveredColor,
+    Line,
+    LineConfig,
+    Manufacturer,
+)
+
+
+def _config() -> LineConfig:
+    return LineConfig(
+        manufacturer=Manufacturer(
+            name="Robert Kaufman",
+            slug="robert-kaufman",
+            website="https://www.robertkaufman.com",
+        ),
+        line=Line(
+            name="Kona Cotton",
+            slug="kona-cotton",
+            substrate="cotton",
+            weight_oz_per_sq_yd=4.35,
+            width_inches=44.0,
+        ),
+        notes="",
+        id_scheme="manufacturer_sku",
+        scraper="kona",
+        product_url_template="https://example.com/{sku}/",
+        image_url_template="https://example.com/{sku}.jpg",
+        skus=[],
+    )
+
+
+def _discovered(sku: str) -> DiscoveredColor:
+    return DiscoveredColor(
+        sku=sku,
+        product_url=f"https://example.com/{sku}/",
+        image_url=f"https://example.com/{sku}.jpg",
+    )
 
 
 def test_url_slug_keeps_per_sku_filename():
@@ -49,3 +88,102 @@ def test_url_slug_strips_unsafe_characters():
     assert "/" not in slug
     assert " " not in slug
     assert slug
+
+
+def _install_stub_get(monkeypatch, responses):
+    """responses: dict[url, bytes | Exception]. Missing URLs return b'OK'."""
+    def fake_get(_session, url):
+        resp = responses.get(url, b"OK")
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+    monkeypatch.setattr(fetch, "_get", fake_get)
+
+
+def test_fetch_skips_sku_on_html_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(fetch, "RAW_DIR", tmp_path)
+    _install_stub_get(monkeypatch, {
+        "https://example.com/K001-002/": fetch.FetchError("boom"),
+    })
+
+    result = fetch.fetch(
+        _config(),
+        [_discovered("K001-001"), _discovered("K001-002"), _discovered("K001-003")],
+    )
+
+    assert [f.sku for f in result.fetched] == ["K001-001", "K001-003"]
+    assert len(result.failures) == 1
+    failure = result.failures[0]
+    assert failure.sku == "K001-002"
+    assert failure.kind == "html"
+    assert failure.url == "https://example.com/K001-002/"
+    assert "boom" in failure.error
+
+
+def test_fetch_skips_sku_on_image_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(fetch, "RAW_DIR", tmp_path)
+    _install_stub_get(monkeypatch, {
+        "https://example.com/K001-002.jpg": fetch.FetchError("403"),
+    })
+
+    result = fetch.fetch(
+        _config(),
+        [_discovered("K001-001"), _discovered("K001-002"), _discovered("K001-003")],
+    )
+
+    assert [f.sku for f in result.fetched] == ["K001-001", "K001-003"]
+    assert len(result.failures) == 1
+    failure = result.failures[0]
+    assert failure.sku == "K001-002"
+    assert failure.kind == "image"
+    assert failure.url == "https://example.com/K001-002.jpg"
+
+
+def test_fetch_all_success_has_no_failures(monkeypatch, tmp_path):
+    monkeypatch.setattr(fetch, "RAW_DIR", tmp_path)
+    _install_stub_get(monkeypatch, {})
+
+    result = fetch.fetch(
+        _config(),
+        [_discovered("K001-001"), _discovered("K001-002")],
+    )
+
+    assert len(result.fetched) == 2
+    assert result.failures == []
+
+
+def test_fetch_all_failures_returns_empty_fetched(monkeypatch, tmp_path):
+    monkeypatch.setattr(fetch, "RAW_DIR", tmp_path)
+    _install_stub_get(monkeypatch, {
+        "https://example.com/K001-001/": fetch.FetchError("x"),
+        "https://example.com/K001-002/": fetch.FetchError("x"),
+    })
+
+    result = fetch.fetch(
+        _config(),
+        [_discovered("K001-001"), _discovered("K001-002")],
+    )
+
+    assert result.fetched == []
+    assert [f.sku for f in result.failures] == ["K001-001", "K001-002"]
+
+
+def test_get_raises_fetch_error_after_retries(monkeypatch):
+    import requests
+
+    calls = {"n": 0}
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            raise requests.HTTPError("403")
+
+    class _FakeSession:
+        def get(self, *_args, **_kwargs):
+            calls["n"] += 1
+            return _FakeResponse()
+
+    monkeypatch.setattr(fetch.time, "sleep", lambda _s: None)
+
+    with pytest.raises(fetch.FetchError):
+        fetch._get(_FakeSession(), "https://example.com/x")
+    assert calls["n"] == fetch.RETRIES + 1


### PR DESCRIPTION
## Summary

- Renames `weekly-update.yml` → `monthly-update.yml` and switches the cron from `0 4 * * 1` to `0 4 1 * *`. Fabric manufacturers publish seasonally, not weekly — monthly is the first cadence where a material change per run is meaningfully probable. Rationale in `docs/decisions.md`.
- Adds per-item fetch resilience (unblocks [#9](https://github.com/kuhrissuh/fabric-color-dataset/issues/9) option A). `fetch.py` now catches `FetchError` per SKU instead of raising on the first failure; failed SKUs are collected into a new `FetchFailure` / `FetchResult` stage-boundary dataclass and carried forward unchanged via merge's existing prior-records path. A third halt threshold (`fetch_failure_rate > 25%`) prevents a systematic block from silently succeeding as "0 material changes." Failures surface in the summary JSON and PR body on both halt and success paths.
- Re-enables the monthly cron. First real run fires 2026-05-01 04:00 UTC — that observation distinguishes hypothesis 1 (sporadic filtering, which this PR handles) from hypothesis 2 (systematic GHA-IP blocking, which would need the runner-model decision).

## Test plan

- [x] `pytest pipeline/tests/` — 157 tests pass (10 new, covering per-item fetch failures, halt threshold, summary surfacing)
- [ ] After merge, trigger `monthly-update.yml` manually via workflow_dispatch to smoke-test resilience against real `robertkaufman.com` traffic from GHA runner IPs
- [ ] Observe the 2026-05-01 scheduled run — small `fetch_failures` count = hypothesis 1 confirmed (issue #9 can close); majority failures or halts = revisit B/C in issue #9