### PR TITLE
Translate Anthropic model-not-found errors into actionable VisionError

### DIFF
--- a/pipeline/src/vision.py
+++ b/pipeline/src/vision.py
@@ -50,31 +50,49 @@ def extract(image_jpeg: bytes) -> VisionResult:
     prompt = _load_prompt()
     encoded = base64.standard_b64encode(image_jpeg).decode("ascii")
 
-    response = client.messages.create(
-        model=MODEL,
-        max_tokens=512,
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "image",
-                        "source": {
-                            "type": "base64",
-                            "media_type": "image/jpeg",
-                            "data": encoded,
+    try:
+        response = client.messages.create(
+            model=MODEL,
+            max_tokens=512,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/jpeg",
+                                "data": encoded,
+                            },
                         },
-                    },
-                    {"type": "text", "text": prompt},
-                ],
-            }
-        ],
-    )
+                        {"type": "text", "text": prompt},
+                    ],
+                }
+            ],
+        )
+    except (anthropic.NotFoundError, anthropic.BadRequestError) as exc:
+        if _is_model_error(exc):
+            raise VisionError(
+                f"Claude API rejected model {MODEL!r} "
+                f"({type(exc).__name__}: {exc}). The model may have been "
+                f"deprecated or retired. Update MODEL in "
+                f"pipeline/src/vision.py to a current Claude vision model "
+                f"and re-run."
+            ) from exc
+        raise
 
     text = _text_from_response(response)
     parsed = _parse_model_output(text)
     _cache_store(key, parsed)
     return _from_json(parsed)
+
+
+def _is_model_error(exc: Exception) -> bool:
+    # Anthropic returns 400 for a retired/unknown model and 404 for some
+    # variants; both surface the word "model" in the message. Keep the
+    # translation narrow so unrelated 400s (e.g. malformed image) bubble up.
+    return "model" in str(exc).lower()
 
 
 def _client() -> anthropic.Anthropic:

--- a/pipeline/tests/test_vision.py
+++ b/pipeline/tests/test_vision.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import MagicMock
 
+import anthropic
+import httpx
 import pytest
 
 import vision
@@ -82,3 +85,51 @@ def test_invalid_confidence_bucket_raises():
     payload = {**VALID, "confidence": "very-high"}
     with pytest.raises(vision.VisionError, match="confidence"):
         vision._parse_model_output(json.dumps(payload))
+
+
+def _anthropic_error(cls, message: str, status: int):
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(status, request=request)
+    return cls(message=message, response=response, body=None)
+
+
+def test_retired_model_not_found_translates(monkeypatch):
+    err = _anthropic_error(
+        anthropic.NotFoundError,
+        f"model: {vision.MODEL}",
+        404,
+    )
+    client = MagicMock()
+    client.messages.create.side_effect = err
+    monkeypatch.setattr(vision, "_client", lambda: client)
+
+    with pytest.raises(vision.VisionError, match="deprecated or retired"):
+        vision.extract(b"not-really-a-jpeg")
+
+
+def test_retired_model_bad_request_translates(monkeypatch):
+    err = _anthropic_error(
+        anthropic.BadRequestError,
+        f"model: {vision.MODEL} has been deprecated",
+        400,
+    )
+    client = MagicMock()
+    client.messages.create.side_effect = err
+    monkeypatch.setattr(vision, "_client", lambda: client)
+
+    with pytest.raises(vision.VisionError, match="deprecated or retired"):
+        vision.extract(b"not-really-a-jpeg-2")
+
+
+def test_unrelated_bad_request_bubbles_up(monkeypatch):
+    err = _anthropic_error(
+        anthropic.BadRequestError,
+        "image exceeds size limit",
+        400,
+    )
+    client = MagicMock()
+    client.messages.create.side_effect = err
+    monkeypatch.setattr(vision, "_client", lambda: client)
+
+    with pytest.raises(anthropic.BadRequestError):
+        vision.extract(b"not-really-a-jpeg-3")


### PR DESCRIPTION
## Summary
- Fixes [#33](https://github.com/kuhrissuh/fabric-color-dataset/issues/33)
- When Anthropic retires or rejects the configured vision model, the pipeline now halts with a clear `VisionError` naming the rejected ID and pointing to the one-line fix in `pipeline/src/vision.py`, instead of surfacing an opaque SDK error mid-run.
- Narrow translation: only `NotFoundError` and `BadRequestError` whose message mentions "model" get rewritten — unrelated 400s (e.g. malformed image) bubble up unchanged.

## Scoped down from the issue
The issue also suggested moving `MODEL` to `configs/` and adding a preflight `models.list()` call. Both skipped per YAGNI: `MODEL` is already a single commented constant (not per-line), and the first vision call fails with the same clear message the preflight would give — just without an extra network round-trip on every run.

## Test plan
- [x] `pytest pipeline/tests/test_vision.py` — 3 new tests (404 path, 400-deprecated path, unrelated-400 bubbles up)
- [x] Full suite: 160 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)